### PR TITLE
TEST Memory Usage Improvements

### DIFF
--- a/lib/obfuscation_helper.rb
+++ b/lib/obfuscation_helper.rb
@@ -3,7 +3,8 @@ require 'bcrypt'
 
 class ObfuscationHelper
   def self.obfuscate (string)
-    hash = BCrypt::Engine.hash_secret string, $kms_client.decrypt(ENV['BCRYPT_SALT'])
-    BCrypt::Password.new(hash).checksum
+    BCrypt::Password.new(
+      BCrypt::Engine.hash_secret string, $kms_client.decrypt(ENV['BCRYPT_SALT'])
+    ).checksum
   end
 end

--- a/lib/patron_batch.rb
+++ b/lib/patron_batch.rb
@@ -7,9 +7,6 @@ class PatronBatch
 
   def initialize(barcodes)
     @barcodes = barcodes
-    @platform_client = ENV['APP_ENV'] == 'local' ?
-      NYPLRubyUtil::PlatformApiClient.new( kms_options: { profile: ENV['AWS_PROFILE'] }) :
-      NYPLRubyUtil::PlatformApiClient.new
   end
 
   def get_resp
@@ -21,7 +18,7 @@ class PatronBatch
     end
 
     begin
-      resp = @platform_client.get("#{ENV['PATRON_ENDPOINT']}?fields=id,barcodes,fixedFields,patronCodes&barcode=#{barcode}")
+      resp = $platform_client.get("#{ENV['PATRON_ENDPOINT']}?fields=id,barcodes,fixedFields,patronCodes&barcode=#{barcode}")
       resp["data"].map {|row| { barcode: barcode, row: row.merge({ "status" => "found" }) }}
     rescue StandardError => e
       $logger.error("#{$batch_id} Failed to fetch patron data for ids #{@barcodes}", { message: e.message })

--- a/lib/query_builder.rb
+++ b/lib/query_builder.rb
@@ -3,7 +3,7 @@
 class QueryBuilder
 
   def self.from (params)
-    "SELECT * FROM #{ENV['TABLE_NAME']} WHERE pcrKey > #{params[:cr_key]}#{self.limit};"
+    "SELECT pcrUserID FROM #{ENV['TABLE_NAME']} WHERE pcrKey > #{params[:cr_key]}#{self.limit};"
   end
 
   def self.limit


### PR DESCRIPTION
This implements a few different improvements to memory usage (hopefully). These strategies are:

1. Refactor all client `.new` calls to the `init` method and use the shared clients. This should primarily help performance but also preventthe creation of many database connection objects (which consume an unknown amount of memory)
2. Remove extra fields from the Envisionware query. Only one column is necessary to be fetched so this reduces load on the db, input I/O and hopefully memory use
3. Refactor some methods to eliminate instance variables. Some Ruby documentation suggests that short strings are not properly garbage collected, and so we should attempt to reduce the number of references to them. It's unclear if this is a real issue, but it can be done safely as long as it doesn't impact the clarity of the code.