### PR TITLE
Add deployment scripts

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -1,0 +1,55 @@
+# On release,
+# build a container and deploy to ECR
+name: Publish to Production
+on:
+  release:
+    types: [released]
+
+jobs:
+  check_production_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      run_other_jobs: ${{ steps.check-production-tag.outputs.run_jobs }}
+    steps:
+      - name: check production tag ${{ github.ref }}
+        id: check-production-tag
+        run: |
+          if [[${{ github.ref }} =~ refs\/tags\/production ]]; then
+            echo "::set-output name=run_jobs::true"
+          else
+            echo "::set-output name=run_jobs::false"
+          fi
+  publish_production:
+    needs: [check_production_tag]
+    if: needs.check_production_tag.outputs.run_other_jobs == 'true'
+    name: Publish image to ECR and update ECS stack
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials from Prod account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: pc_reserve_poller
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster pc-reserve-poller-production --service pc-reserve-poller-app-production --force-new-deployment
+          aws ecs run-task --cluster pc-reserve-poller-production --task-definition pc-reserve-poller-app-production:14 --count 1

--- a/.github/workflows/build-qa.yaml
+++ b/.github/workflows/build-qa.yaml
@@ -1,0 +1,55 @@
+# On release,
+# build a container and deploy to ECR
+name: Publish to QA
+on:
+  release:
+    types: [released]
+
+jobs:
+  check_qa_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      run_other_jobs: ${{ steps.check-qa-tag.outputs.run_jobs }}
+    steps:
+      - name: check qa tag ${{ github.ref }}
+        id: check-qa-tag
+        run: |
+          if [[${{ github.ref }} =~ refs\/tags\/qa ]]; then
+            echo "::set-output name=run_jobs::true"
+          else
+            echo "::set-output name=run_jobs::false"
+          fi
+  publish_qa:
+    needs: [check_qa_tag]
+    if: needs.check_qa_tag.outputs.run_other_jobs == 'true'
+    name: Publish image to ECR and update ECS stack
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials from Prod account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: pc_reserve_poller
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster pc-reserve-poller-qa --service pc-reserve-poller-app-qa --force-new-deployment
+          aws ecs run-task --cluster pc-reserve-poller-qa --task-definition pc-reserve-poller-app-qa:14 --count 1


### PR DESCRIPTION
This is supposed to add some GitHub actions so that we deploy to qa/prod whenever a release is released with qa/prod in the title. This is meant to allow us to update the code without necessarily having to restart the application if we don't want to.

"Deploy" here means two things:

1. Push the new image
2. Restart the new image.

The logic is based on this: https://github.community/t/how-to-trigger-on-a-release-only-if-tag-name-matches-pattern/18514/2

Not familiar at all with how this works so please let me know if it looks right.