### PR TITLE
Retry Sierra query if it errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2023-05-24 -- v0.0.2
+### Fixed
+- Added retry if Sierra query times out
+
 ## 2023-04-14 -- v0.0.1
 ### Added
 - Initial python commit

--- a/config/devel.yaml
+++ b/config/devel.yaml
@@ -7,8 +7,8 @@ PLAINTEXT_VARIABLES:
     SIERRA_DB_NAME: iii
     REDSHIFT_DB_NAME: qa
     ENVISIONWARE_BATCH_SIZE: 20
-    S3_BUCKET: bic-poller-states-qa
-    S3_RESOURCE: pc_reserve_poller_state.json
+    S3_BUCKET:
+    S3_RESOURCE:
     PC_RESERVE_SCHEMA_URL: https://qa-platform.nypl.org/api/v0.1/current-schemas/PcReserve
     KINESIS_BATCH_SIZE: 20
     LOG_LEVEL: info

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -20,6 +20,7 @@ class TestHelpers:
         'REDSHIFT_DB_USER': 'test_redshift_user',
         'REDSHIFT_DB_PASSWORD': 'test_redshift_password',
         'ENVISIONWARE_BATCH_SIZE': '4',
+        'MAX_BATCHES': '1',
         'S3_BUCKET': 'test_s3_bucket',
         'S3_RESOURCE': 'test_s3_resource',
         'PC_RESERVE_SCHEMA_URL': 'https://test_schema_url',


### PR DESCRIPTION
The first query often times out in QA Sierra but will succeed the second go around after the database has been prepared.

Also cleaned up testing environment variable setting.