### PR TITLE
Do not use patron info for any barcodes that correspond to multiple records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 __pycache__/
+.vscode/
 *env/
 *.py[cod]
 *$py.class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2023-05-25 -- v0.0.3
+### Fixed
+- If a barcode corresponds to multiple Sierra patron records, do not use any of the patron info
+- Handle second Sierra query timeout
+
 ## 2023-05-24 -- v0.0.2
 ### Fixed
 - Added retry if Sierra query times out

--- a/config/devel.yaml
+++ b/config/devel.yaml
@@ -6,7 +6,7 @@ PLAINTEXT_VARIABLES:
     SIERRA_DB_PORT: 1032
     SIERRA_DB_NAME: iii
     REDSHIFT_DB_NAME: qa
-    ENVISIONWARE_BATCH_SIZE: 500
+    ENVISIONWARE_BATCH_SIZE: 20
     S3_BUCKET:
     S3_RESOURCE:
     PC_RESERVE_SCHEMA_URL: https://qa-platform.nypl.org/api/v0.1/current-schemas/PcReserve

--- a/config/devel.yaml
+++ b/config/devel.yaml
@@ -6,7 +6,7 @@ PLAINTEXT_VARIABLES:
     SIERRA_DB_PORT: 1032
     SIERRA_DB_NAME: iii
     REDSHIFT_DB_NAME: qa
-    ENVISIONWARE_BATCH_SIZE: 20
+    ENVISIONWARE_BATCH_SIZE: 500
     S3_BUCKET:
     S3_RESOURCE:
     PC_RESERVE_SCHEMA_URL: https://qa-platform.nypl.org/api/v0.1/current-schemas/PcReserve

--- a/main.py
+++ b/main.py
@@ -84,8 +84,8 @@ def main():
             logger.info('Querying Sierra for patron information by barcode')
             sierra_raw_data = sierra_client.execute_query(sierra_query)
         except PostgreSQLClientError:
-            logger.info('First query failed -- trying again')
             try:
+                logger.info('First query failed -- trying again')
                 sierra_raw_data = sierra_client.execute_query(sierra_query)
             except PostgreSQLClientError as e:
                 logger.error(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flake8
-nypl-py-utils[avro-encoder,kinesis-client,mysql-client,postgresql-client,redshift-client,s3-client,config-helper,obfuscation-helper]==1.0.1
+nypl-py-utils[avro-encoder,kinesis-client,mysql-client,postgresql-client,redshift-client,s3-client,config-helper,obfuscation-helper]==1.0.3
 pandas
 pytest
 pytest-mock


### PR DESCRIPTION
Also:

Temporarily suppress PostgreSQLClient logging to avoid logging an error if the query times out the first time but succeeds the second

Handle two Sierra query failures by logging an error, closing all connections, and re-raising the error